### PR TITLE
Multimedia scaffolding

### DIFF
--- a/lib/rumble/multimedia/multimedia.ex
+++ b/lib/rumble/multimedia/multimedia.ex
@@ -1,0 +1,104 @@
+defmodule Rumble.Multimedia do
+  @moduledoc """
+  The Multimedia context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Rumble.Repo
+
+  alias Rumble.Multimedia.Video
+
+  @doc """
+  Returns the list of videos.
+
+  ## Examples
+
+      iex> list_videos()
+      [%Video{}, ...]
+
+  """
+  def list_videos do
+    Repo.all(Video)
+  end
+
+  @doc """
+  Gets a single video.
+
+  Raises `Ecto.NoResultsError` if the Video does not exist.
+
+  ## Examples
+
+      iex> get_video!(123)
+      %Video{}
+
+      iex> get_video!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_video!(id), do: Repo.get!(Video, id)
+
+  @doc """
+  Creates a video.
+
+  ## Examples
+
+      iex> create_video(%{field: value})
+      {:ok, %Video{}}
+
+      iex> create_video(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_video(attrs \\ %{}) do
+    %Video{}
+    |> Video.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a video.
+
+  ## Examples
+
+      iex> update_video(video, %{field: new_value})
+      {:ok, %Video{}}
+
+      iex> update_video(video, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_video(%Video{} = video, attrs) do
+    video
+    |> Video.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Video.
+
+  ## Examples
+
+      iex> delete_video(video)
+      {:ok, %Video{}}
+
+      iex> delete_video(video)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_video(%Video{} = video) do
+    Repo.delete(video)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking video changes.
+
+  ## Examples
+
+      iex> change_video(video)
+      %Ecto.Changeset{source: %Video{}}
+
+  """
+  def change_video(%Video{} = video) do
+    Video.changeset(video, %{})
+  end
+end

--- a/lib/rumble/multimedia/video.ex
+++ b/lib/rumble/multimedia/video.ex
@@ -1,0 +1,21 @@
+defmodule Rumble.Multimedia.Video do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+
+  schema "videos" do
+    field :description, :string
+    field :title, :string
+    field :url, :string
+    belongs_to :user, Rumble.Accounts.User
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(video, attrs) do
+    video
+    |> cast(attrs, [:url, :title, :description])
+    |> validate_required([:url, :title, :description])
+  end
+end

--- a/lib/rumble_web.ex
+++ b/lib/rumble_web.ex
@@ -23,6 +23,7 @@ defmodule RumbleWeb do
 
       import Plug.Conn
       import RumbleWeb.Gettext
+      import RumbleWeb.Auth, only: [authenticate_user: 2]
       alias RumbleWeb.Router.Helpers, as: Routes
     end
   end
@@ -50,6 +51,7 @@ defmodule RumbleWeb do
       use Phoenix.Router
       import Plug.Conn
       import Phoenix.Controller
+      import RumbleWeb.Auth, only: [authenticate_user: 2]
     end
   end
 

--- a/lib/rumble_web/controllers/auth.ex
+++ b/lib/rumble_web/controllers/auth.ex
@@ -1,7 +1,9 @@
 defmodule RumbleWeb.Auth do
   import Plug.Conn
+  import Phoenix.Controller
 
   alias Rumble.Accounts
+  alias RumbleWeb.Router.Helpers, as: Routes
 
   def init(opts), do: opts
 
@@ -28,5 +30,16 @@ defmodule RumbleWeb.Auth do
 
   def logout(conn) do
     configure_session(conn, drop: true)
+  end
+
+  def authenticate_user(conn, _opts) do
+    if conn.assigns.current_user do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You must be logged in to access that page")
+      |> redirect(to: Routes.page_path(conn, :index))
+      |> halt()
+    end
   end
 end

--- a/lib/rumble_web/controllers/user_controller.ex
+++ b/lib/rumble_web/controllers/user_controller.ex
@@ -4,7 +4,7 @@ defmodule RumbleWeb.UserController do
   alias Rumble.Accounts
   alias Rumble.Accounts.User
 
-  plug :authenticate when action in [:index, :show]
+  plug :authenticate_user when action in [:index, :show]
 
   def new(conn, _params) do
     changeset = Accounts.change_user(%User{})
@@ -32,16 +32,5 @@ defmodule RumbleWeb.UserController do
   def show(conn, %{"id" => id}) do
     user = Accounts.get_user(id)
     render(conn, "show.html", user: user)
-  end
-
-  defp authenticate(conn, _opts) do
-    if conn.assigns.current_user do
-      conn
-    else
-      conn
-      |> put_flash(:error, "You must be logged in to access that page")
-      |> redirect(to: Routes.page_path(conn, :index))
-      |> halt()
-    end
   end
 end

--- a/lib/rumble_web/controllers/video_controller.ex
+++ b/lib/rumble_web/controllers/video_controller.ex
@@ -4,18 +4,18 @@ defmodule RumbleWeb.VideoController do
   alias Rumble.Multimedia
   alias Rumble.Multimedia.Video
 
-  def index(conn, _params) do
-    videos = Multimedia.list_videos()
+  def index(conn, _params, current_user) do
+    videos = Multimedia.list_user_videos(current_user)
     render(conn, "index.html", videos: videos)
   end
 
-  def new(conn, _params) do
-    changeset = Multimedia.change_video(%Video{})
+  def new(conn, _params, current_user) do
+    changeset = Multimedia.change_video(current_user, %Video{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(conn, %{"video" => video_params}) do
-    case Multimedia.create_video(video_params) do
+  def create(conn, %{"video" => video_params}, current_user) do
+    case Multimedia.create_video(current_user, video_params) do
       {:ok, video} ->
         conn
         |> put_flash(:info, "Video created successfully.")
@@ -26,19 +26,19 @@ defmodule RumbleWeb.VideoController do
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    video = Multimedia.get_video!(id)
+  def show(conn, %{"id" => id}, current_user) do
+    video = Multimedia.get_user_video!(current_user, id)
     render(conn, "show.html", video: video)
   end
 
-  def edit(conn, %{"id" => id}) do
-    video = Multimedia.get_video!(id)
-    changeset = Multimedia.change_video(video)
+  def edit(conn, %{"id" => id}, current_user) do
+    video = Multimedia.get_user_video!(current_user, id)
+    changeset = Multimedia.change_video(current_user, video)
     render(conn, "edit.html", video: video, changeset: changeset)
   end
 
-  def update(conn, %{"id" => id, "video" => video_params}) do
-    video = Multimedia.get_video!(id)
+  def update(conn, %{"id" => id, "video" => video_params}, current_user) do
+    video = Multimedia.get_user_video!(current_user, id)
 
     case Multimedia.update_video(video, video_params) do
       {:ok, video} ->
@@ -51,12 +51,17 @@ defmodule RumbleWeb.VideoController do
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    video = Multimedia.get_video!(id)
+  def delete(conn, %{"id" => id}, current_user) do
+    video = Multimedia.get_user_video!(current_user, id)
     {:ok, _video} = Multimedia.delete_video(video)
 
     conn
     |> put_flash(:info, "Video deleted successfully.")
     |> redirect(to: Routes.video_path(conn, :index))
+  end
+
+  def action(conn, _) do
+    args = [conn, conn.params, conn.assigns.current_user]
+    apply(__MODULE__, action_name(conn), args)
   end
 end

--- a/lib/rumble_web/controllers/video_controller.ex
+++ b/lib/rumble_web/controllers/video_controller.ex
@@ -1,0 +1,62 @@
+defmodule RumbleWeb.VideoController do
+  use RumbleWeb, :controller
+
+  alias Rumble.Multimedia
+  alias Rumble.Multimedia.Video
+
+  def index(conn, _params) do
+    videos = Multimedia.list_videos()
+    render(conn, "index.html", videos: videos)
+  end
+
+  def new(conn, _params) do
+    changeset = Multimedia.change_video(%Video{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"video" => video_params}) do
+    case Multimedia.create_video(video_params) do
+      {:ok, video} ->
+        conn
+        |> put_flash(:info, "Video created successfully.")
+        |> redirect(to: Routes.video_path(conn, :show, video))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    video = Multimedia.get_video!(id)
+    render(conn, "show.html", video: video)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    video = Multimedia.get_video!(id)
+    changeset = Multimedia.change_video(video)
+    render(conn, "edit.html", video: video, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "video" => video_params}) do
+    video = Multimedia.get_video!(id)
+
+    case Multimedia.update_video(video, video_params) do
+      {:ok, video} ->
+        conn
+        |> put_flash(:info, "Video updated successfully.")
+        |> redirect(to: Routes.video_path(conn, :show, video))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", video: video, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    video = Multimedia.get_video!(id)
+    {:ok, _video} = Multimedia.delete_video(video)
+
+    conn
+    |> put_flash(:info, "Video deleted successfully.")
+    |> redirect(to: Routes.video_path(conn, :index))
+  end
+end

--- a/lib/rumble_web/router.ex
+++ b/lib/rumble_web/router.ex
@@ -22,6 +22,12 @@ defmodule RumbleWeb.Router do
     resources "/sessions", SessionController, only: [:new, :create, :delete]
   end
 
+  scope "/manage", RumbleWeb do
+    pipe_through [:browser, :authenticate_user]
+
+    resources "/videos", VideoController
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", RumbleWeb do
   #   pipe_through :api

--- a/lib/rumble_web/templates/video/edit.html.eex
+++ b/lib/rumble_web/templates/video/edit.html.eex
@@ -1,0 +1,5 @@
+<h1>Edit Video</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.video_path(@conn, :update, @video)) %>
+
+<span><%= link "Back", to: Routes.video_path(@conn, :index) %></span>

--- a/lib/rumble_web/templates/video/form.html.eex
+++ b/lib/rumble_web/templates/video/form.html.eex
@@ -1,0 +1,23 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :url %>
+  <%= text_input f, :url %>
+  <%= error_tag f, :url %>
+
+  <%= label f, :title %>
+  <%= text_input f, :title %>
+  <%= error_tag f, :title %>
+
+  <%= label f, :description %>
+  <%= textarea f, :description %>
+  <%= error_tag f, :description %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+<% end %>

--- a/lib/rumble_web/templates/video/index.html.eex
+++ b/lib/rumble_web/templates/video/index.html.eex
@@ -1,0 +1,30 @@
+<h1>Listing Videos</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Url</th>
+      <th>Title</th>
+      <th>Description</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for video <- @videos do %>
+    <tr>
+      <td><%= video.url %></td>
+      <td><%= video.title %></td>
+      <td><%= video.description %></td>
+
+      <td>
+        <%= link "Show", to: Routes.video_path(@conn, :show, video) %>
+        <%= link "Edit", to: Routes.video_path(@conn, :edit, video) %>
+        <%= link "Delete", to: Routes.video_path(@conn, :delete, video), method: :delete, data: [confirm: "Are you sure?"] %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Video", to: Routes.video_path(@conn, :new) %></span>

--- a/lib/rumble_web/templates/video/new.html.eex
+++ b/lib/rumble_web/templates/video/new.html.eex
@@ -1,0 +1,5 @@
+<h1>New Video</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.video_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.video_path(@conn, :index) %></span>

--- a/lib/rumble_web/templates/video/show.html.eex
+++ b/lib/rumble_web/templates/video/show.html.eex
@@ -1,0 +1,23 @@
+<h1>Show Video</h1>
+
+<ul>
+
+  <li>
+    <strong>Url:</strong>
+    <%= @video.url %>
+  </li>
+
+  <li>
+    <strong>Title:</strong>
+    <%= @video.title %>
+  </li>
+
+  <li>
+    <strong>Description:</strong>
+    <%= @video.description %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.video_path(@conn, :edit, @video) %></span>
+<span><%= link "Back", to: Routes.video_path(@conn, :index) %></span>

--- a/lib/rumble_web/views/video_view.ex
+++ b/lib/rumble_web/views/video_view.ex
@@ -1,0 +1,3 @@
+defmodule RumbleWeb.VideoView do
+  use RumbleWeb, :view
+end

--- a/priv/repo/migrations/20190121010714_create_videos.exs
+++ b/priv/repo/migrations/20190121010714_create_videos.exs
@@ -1,0 +1,16 @@
+defmodule Rumble.Repo.Migrations.CreateVideos do
+  use Ecto.Migration
+
+  def change do
+    create table(:videos) do
+      add :url, :string
+      add :title, :string
+      add :description, :text
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:videos, [:user_id])
+  end
+end

--- a/test/rumble/multimedia/multimedia_test.exs
+++ b/test/rumble/multimedia/multimedia_test.exs
@@ -1,0 +1,68 @@
+defmodule Rumble.MultimediaTest do
+  use Rumble.DataCase
+
+  alias Rumble.Multimedia
+
+  describe "videos" do
+    alias Rumble.Multimedia.Video
+
+    @valid_attrs %{description: "some description", title: "some title", url: "some url"}
+    @update_attrs %{description: "some updated description", title: "some updated title", url: "some updated url"}
+    @invalid_attrs %{description: nil, title: nil, url: nil}
+
+    def video_fixture(attrs \\ %{}) do
+      {:ok, video} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Multimedia.create_video()
+
+      video
+    end
+
+    test "list_videos/0 returns all videos" do
+      video = video_fixture()
+      assert Multimedia.list_videos() == [video]
+    end
+
+    test "get_video!/1 returns the video with given id" do
+      video = video_fixture()
+      assert Multimedia.get_video!(video.id) == video
+    end
+
+    test "create_video/1 with valid data creates a video" do
+      assert {:ok, %Video{} = video} = Multimedia.create_video(@valid_attrs)
+      assert video.description == "some description"
+      assert video.title == "some title"
+      assert video.url == "some url"
+    end
+
+    test "create_video/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Multimedia.create_video(@invalid_attrs)
+    end
+
+    test "update_video/2 with valid data updates the video" do
+      video = video_fixture()
+      assert {:ok, %Video{} = video} = Multimedia.update_video(video, @update_attrs)
+      assert video.description == "some updated description"
+      assert video.title == "some updated title"
+      assert video.url == "some updated url"
+    end
+
+    test "update_video/2 with invalid data returns error changeset" do
+      video = video_fixture()
+      assert {:error, %Ecto.Changeset{}} = Multimedia.update_video(video, @invalid_attrs)
+      assert video == Multimedia.get_video!(video.id)
+    end
+
+    test "delete_video/1 deletes the video" do
+      video = video_fixture()
+      assert {:ok, %Video{}} = Multimedia.delete_video(video)
+      assert_raise Ecto.NoResultsError, fn -> Multimedia.get_video!(video.id) end
+    end
+
+    test "change_video/1 returns a video changeset" do
+      video = video_fixture()
+      assert %Ecto.Changeset{} = Multimedia.change_video(video)
+    end
+  end
+end

--- a/test/rumble_web/controllers/video_controller_test.exs
+++ b/test/rumble_web/controllers/video_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule RumbleWeb.VideoControllerTest do
+  use RumbleWeb.ConnCase
+
+  alias Rumble.Multimedia
+
+  @create_attrs %{description: "some description", title: "some title", url: "some url"}
+  @update_attrs %{description: "some updated description", title: "some updated title", url: "some updated url"}
+  @invalid_attrs %{description: nil, title: nil, url: nil}
+
+  def fixture(:video) do
+    {:ok, video} = Multimedia.create_video(@create_attrs)
+    video
+  end
+
+  describe "index" do
+    test "lists all videos", %{conn: conn} do
+      conn = get(conn, Routes.video_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Videos"
+    end
+  end
+
+  describe "new video" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.video_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Video"
+    end
+  end
+
+  describe "create video" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.video_path(conn, :create), video: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.video_path(conn, :show, id)
+
+      conn = get(conn, Routes.video_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Video"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.video_path(conn, :create), video: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Video"
+    end
+  end
+
+  describe "edit video" do
+    setup [:create_video]
+
+    test "renders form for editing chosen video", %{conn: conn, video: video} do
+      conn = get(conn, Routes.video_path(conn, :edit, video))
+      assert html_response(conn, 200) =~ "Edit Video"
+    end
+  end
+
+  describe "update video" do
+    setup [:create_video]
+
+    test "redirects when data is valid", %{conn: conn, video: video} do
+      conn = put(conn, Routes.video_path(conn, :update, video), video: @update_attrs)
+      assert redirected_to(conn) == Routes.video_path(conn, :show, video)
+
+      conn = get(conn, Routes.video_path(conn, :show, video))
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, video: video} do
+      conn = put(conn, Routes.video_path(conn, :update, video), video: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Video"
+    end
+  end
+
+  describe "delete video" do
+    setup [:create_video]
+
+    test "deletes chosen video", %{conn: conn, video: video} do
+      conn = delete(conn, Routes.video_path(conn, :delete, video))
+      assert redirected_to(conn) == Routes.video_path(conn, :index)
+      assert_error_sent 404, fn ->
+        get(conn, Routes.video_path(conn, :show, video))
+      end
+    end
+  end
+
+  defp create_video(_) do
+    video = fixture(:video)
+    {:ok, video: video}
+  end
+end


### PR DESCRIPTION
Created the context for multimedia, which currently only uses the video schema, but has been built out in a way where we could easily extend the functionality to include other types of media.

Included the ability to submit videos through a form, edit videos, and view videos. This is all tied to a user session. Currently, cannot view videos belonging to other users.